### PR TITLE
Move sending process to a background thread. Closes issue #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 env.list
 env/
+.env
 .idea
 db.sqlite3
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Dynamically extract phone numbers from a defined Google Sheets to send bulk mess
 
 Your Twilio phone number can be blacklisted as spam by carriers if you're sending bulk SMS. Read this [FAQ](https://support.twilio.com/hc/en-us/articles/223181708-Can-my-Twilio-SMS-messages-be-blacklisted-as-spam-).
 If you plan on sending bulk SMS on a regular basis, this is not the right software.
-You should consider obtaining and using [short codes](https://www.twilio.com/sms/shortcodes) to avoid being blacklisted. They are also much faster than a normal Twilio phone number.
-HackCU and its developers are not responsible if you are blacklisted while using this tool.
+You should consider obtaining and using [short codes](https://www.twilio.com/sms/shortcodes) to avoid being blacklisted.
+They are also much faster than a normal Twilio phone number.
+HackCU and its developers are not responsible if you get blacklisted while using this tool.
 
-This was built for a hackathon and will be used only for about 2 days in a year to send notifications to participants (who are aware of this and voluntarily provided their phone numbers).
+This was built for a hackathon and will be used only for about 2 days in a year to send notifications to participants (who are aware of this and voluntarily provide their phone numbers).
 So, if your use case is similar, you shouldn't run into any issues of being blocked by carriers.
 
 ## Setup
@@ -23,6 +24,7 @@ Needs: Python 3.X
 
 ```shell
 $ pip install -r requirements.txt
+$ mkdir db
 $ python manage.py migrate
 $ python manage.py createsuperuser
 ```
@@ -47,9 +49,9 @@ $ python manage.py runserver 0.0.0.0:8000
 
 ### Docker
 
-In order to make deployment easier, there's an available built image.
+In order to make deployment easier, there's a built image available.
 
-Needs: docker
+Needs: `docker`
 
 - Create a directory
 - Copy `docker_run.sh` into the directory

--- a/README.md
+++ b/README.md
@@ -4,17 +4,28 @@
 </p>
 <br>
 
-
+# MercurySMS
 Dynamically extract phone numbers from a defined Google Sheets to send bulk messages with Twilio.
 
+## Note
+
+Your Twilio phone number can be blacklisted as spam by carriers if you're sending bulk SMS. Read this [FAQ](https://support.twilio.com/hc/en-us/articles/223181708-Can-my-Twilio-SMS-messages-be-blacklisted-as-spam-).
+If you plan on sending bulk SMS on a regular basis, this is not the right software.
+You should consider obtaining and using [short codes](https://www.twilio.com/sms/shortcodes) to avoid being blacklisted. They are also much faster than a normal Twilio phone number.
+HackCU and its developers are not responsible if you are blacklisted while using this tool.
+
+This was built for a hackathon and will be used only for about 2 days in a year to send notifications to participants (who are aware of this and voluntarily provided their phone numbers).
+So, if your use case is similar, you shouldn't run into any issues of being blocked by carriers.
+
 ## Setup
+
 Needs: Python 3.X
 
-- `pip install -r requirements.txt`
-- `python manage.py migrate`
-- `python manage.py createsuperuser`
-
-
+```shell
+$ pip install -r requirements.txt
+$ python manage.py migrate
+$ python manage.py createsuperuser
+```
 
 ## Run server
 
@@ -26,12 +37,13 @@ Add 4 (2 optional) environment variables:
 - **TOKEN_TWILIO**: Twilio account SID
 - **FROM_TWILIO**: Twilio phone number. **Needs to be able to send SMS to unverified numbers**
 - **SHEETS_KEY**: Google Sheets key. Ex: https://docs.google.com/spreadsheets/d/**ajksdhalksdhalksdhlaksjawdlS83zL3I**/edit
-- **SHEETS_GID**(optional): Tab that you want to extract from Google Sheets. Defaults to 0, first tab. You can find it on the URL. Ex: https://docs.google.com/spreadsheets/d/1Fo58xcUnCUN2-_1Rjua2lW6b85IDQ2gK9wdlS83zL3I/edit#**gid=0** 
+- **SHEETS_GID**(optional): Tab that you want to extract from Google Sheets. Defaults to 0, first tab. You can find it on the URL. Ex: https://docs.google.com/spreadsheets/d/1Fo58xcUnCUN2-_1Rjua2lW6b85IDQ2gK9wdlS83zL3I/edit#**gid=0**
 - **PROD**(optional): Run project on production mode. Any value will make it run as production mode.
 
 Run server to 0.0.0.0
-`python manage.py runserver 0.0.0.0:8000`
-
+```shell
+$ python manage.py runserver 0.0.0.0:8000
+```
 
 ### Docker
 
@@ -47,10 +59,6 @@ Needs: docker
 - Login in the app as `admin` (password `admin`) and change the password for admin (and username too) from the admin console.
 - Enjoy!
 
-
-
-
-
 ## Usage
 
 ### Create Google Sheets
@@ -65,7 +73,7 @@ A list is a column in the mentioned Google Sheets. It is identified by each firs
 
 - Open root route. Ex: http://localhost:8000
 - Login with user (you can login with the super user you created in your first steps)
-- Send messages right away. Let's SPAM those users :D
+- Send messages right away.
 
 ### Add new users
 
@@ -76,9 +84,9 @@ A list is a column in the mentioned Google Sheets. It is identified by each firs
 
 ## Future
 
-- Add hability to receive SMS
-- Answer SMS received individually
-- Keep a log of all messages sent and to what numbers
+- [ ] Add ability to receive SMS
+- [ ] Answer SMS received individually
+- [ ] Keep a log of all messages sent and recipients
 
 
 ----------------

--- a/mercurysms/templates/base.html
+++ b/mercurysms/templates/base.html
@@ -5,6 +5,7 @@
     <meta charset="UTF-8">
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
     <script src="https://code.jquery.com/jquery-3.1.1.slim.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
             integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
             crossorigin="anonymous"></script>
@@ -20,7 +21,11 @@
           content="Dynamically extract phone numbers from a defined GSheets to send bulk messages with Twilio"/>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link href="https://fonts.googleapis.com/css?family=Ek+Mukta" rel="stylesheet">
+    
     {% block head %}
+    {% endblock %}
+
+    {% block javascript %}
     {% endblock %}
 
     <title>{% block title %}{% endblock %} - MercurySMS</title>

--- a/mercurysms/templates/sending.html
+++ b/mercurysms/templates/sending.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% load bootstrap3 %}
+{% load static %}
+{% block title %}Sending messages{% endblock %}
+
+{% block javascript %}
+    <script>
+      $(document).ready(function() {
+        var refresh_id = setInterval(function() {
+            $.get(
+              "{% url 'status' %}",
+              function(data) {
+                console.log(data);
+                if (data.finished) {
+                  window.location.replace("{% url 'sms_sent' %}");
+                }
+              }
+            )}
+          , 2000);
+      });
+    </script>
+{% endblock %}
+    
+{% block body %}
+    <div class="col-md-8 col-md-offset-2">
+        <div class="panel panel-danger margin-top">
+            <div class="panel-heading">
+                <h3 class="panel-title">Sending messages</h3>
+            </div>
+            <div class="panel-body">
+                We are attempting to send the message to everyone in the list.
+                <br>
+                This might take a while if your list is large.
+                <br>
+                It takes apporximately 1 second to process 1 request. So please be patient.
+                <br>
+                We will redirect you once we've finished. Don't attempt to stop the process.
+            </div>
+            <div class="panel-footer">
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/mercurysms/urls.py
+++ b/mercurysms/urls.py
@@ -24,4 +24,6 @@ urlpatterns = [
     url(r'^accounts/logout/$', auth_views.logout, {'template_name': 'registration/logout.html'},name='logout'),
     url(r'^$', views.SendSMSView.as_view(), name='send_form'),
     url(r'^sent/$', views.succesfully_sent, name='sms_sent'),
+    url(r'^sending/$', views.sending, name='sending'),
+    url(r'^status/$', views.status, name='status'),
 ]

--- a/mercurysms/views.py
+++ b/mercurysms/views.py
@@ -1,16 +1,19 @@
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.views.generic import TemplateView
 from mercurysms import sheets
 from mercurysms import twilio
+from mercurysms import worker
 from mercurysms.forms import SendSMSForm
 
 SHEETS_KEY = getattr(settings, "SHEETS_KEY", None)
 SHEETS_GID = getattr(settings, "SHEETS_GID", None)
 
+bg_worker = worker.Worker()
 
 class SendSMSView(LoginRequiredMixin, TemplateView):
     template_name = 'sendSMS.html'
@@ -18,6 +21,7 @@ class SendSMSView(LoginRequiredMixin, TemplateView):
     def __init__(self):
         super(SendSMSView, self).__init__()
         self.sheet = sheets.Sheet(SHEETS_KEY, SHEETS_GID)
+        bg_worker = worker.Worker()
 
     def get_context_data(self, **kwargs):
         con = super(SendSMSView, self).get_context_data(**kwargs)
@@ -32,18 +36,24 @@ class SendSMSView(LoginRequiredMixin, TemplateView):
         for list_ in lists:
             numbers = numbers.union(set(self.sheet.get_list(list_)))
         message = request.POST.get('message')
-        err_nums, cost = twilio.mass_sms(message, list(numbers))
-        url = reverse('sms_sent') + '?q=1'
-        if err_nums:
-            url += '&nums=' + ','.join(err_nums)
-        if cost:
-            url += '&cost=' + str(cost)
-        return redirect(url)
+        bg_worker.start_process(message, list(numbers))
+        return redirect('sending')
 
 
 @login_required
 def succesfully_sent(request):
-    nums = request.GET.get('nums', None)
-    cost = request.GET.get('cost', 0.0)
+    nums = bg_worker.err_nums
+    cost = bg_worker.cost
+    bg_worker.reset()
     context = {'nums': nums, 'cost': cost}
     return render(request, 'sms_sent.html', context=context)
+
+
+@login_required
+def sending(request):
+    return render(request, 'sending.html')
+
+
+def status(request):
+    data = { 'finished': bg_worker.done }
+    return JsonResponse(data)

--- a/mercurysms/worker.py
+++ b/mercurysms/worker.py
@@ -1,0 +1,24 @@
+from threading import Thread
+from mercurysms import twilio
+
+class Worker:
+
+	def __init__(self):
+		self.worker = Thread()
+		self.err_nums = []
+		self.cost = 0.0
+		self.done = False
+
+	def start_process(self, message, numbers):
+		self.worker = Thread(target=self.__process, args=(message, numbers))
+		self.worker.start()
+
+	def reset(self):
+		self.worker = Thread()
+		self.err_nums = []
+		self.cost = 0.0
+		self.done = False
+
+	def __process(self, message, numbers):
+		self.err_nums, self.cost = twilio.mass_sms(message, numbers)
+		self.done = True


### PR DESCRIPTION
## Changes
* Created a background worker with a thread and delegated sending SMS to the worker.
* Created a new `sending` view to which the user is redirected to. This view makes AJAX calls every 2 seconds to check for completion of thread. Upon completion, user is redirected to `successfully_sent` view.
* Updated README.md to warn users of the potential to be blacklisted by phone carriers. Other minor edits to setup instructions.

### Files added
* `mercurysms/templates/sending.html`
* `mercurysms/worker.py`

### Files modified
* `.gitignore`
* `README.md`
* `mercurysms/templates/base.html`
* `mercurysms/urls.py`
* ` mercurysms/views.py`